### PR TITLE
data: Mark release descriptions as untranslatable

### DIFF
--- a/data/net.natesales.Aviator.metainfo.xml
+++ b/data/net.natesales.Aviator.metainfo.xml
@@ -57,7 +57,7 @@
   <releases>
 
     <release version="0.4.2" date="2023-09-09">
-      <description>
+      <description translatable="no">
         <p>Updated SVT-AV1 to 1.7.0, which features rebalanced presets &amp; more massive speed improvements</p>
         <p>In light of SVT-AV1's speedy development, Preset 7 is now high enough quality to be featured as Aviator's default speed preset</p>
         <p>"Copy Audio" now disables other audio options in the GUI</p>
@@ -67,7 +67,7 @@
     </release>
 
     <release version="0.4.1" date="2023-07-06">
-      <description>
+      <description translatable="no">
         <p>Updated SVT-AV1 fork promises up to a 40% speed improvement for higher quality presets (p5 &amp; lower)</p>
         <p>New "Crop" option for switching between cropping &amp; scaling resolution</p>
         <p>Updated SVT-AV1 parameters for an 0.3-0.8% perceptual quality improvement</p>
@@ -75,7 +75,7 @@
     </release>
 
     <release version="0.4.0" date="2023-05-26">
-      <description>
+      <description translatable="no">
         <p>Custom, perceptually optimized fork of SVT-AV1 featuring a bleeding edge tune that outperforms the latest release in visual quality per bit.</p>
         <p>New audio filters, Volume &amp; Normalization, available through a slider &amp; a toggle respectively on the Audio page.</p>
         <p>Prettier SVT-AV1 parameter handling in the codebase.</p>
@@ -83,7 +83,7 @@
     </release>
 
     <release version="0.3.0" date="2023-05-10">
-      <description>
+      <description translatable="no">
         <p>New "Copy Audio" switch that allows passing the audio through without reencoding (disables WebM output).</p>
         <p>Improved resolution scaling with automatic width/height adjustment based on one resolution input value &amp; a less aggressive default scaling algorithm (Catmull-Rom).</p>
         <p>Removed "Match Source" buttons - resolution will match source if left empty, &amp; audio won't be reencoded at an identical bitrate (this is not smart to do).</p>
@@ -94,20 +94,20 @@
     </release>
 
     <release version="0.2.2" date="2023-05-02">
-      <description>
+      <description translatable="no">
         <p>Updated to FFmpeg 6.0</p>
         <p>Updated to SVT-AV1 1.5.0</p>
       </description>
     </release>
 
     <release version="0.2.1a" date="2023-02-14">
-      <description>
+      <description translatable="no">
         <p>Fix: subtitle &amp; audio mapping. If your encodes were not moving past 0%, this should fix it.</p>
       </description>
     </release>
 
     <release version="0.2.1" date="2023-02-14">
-      <description>
+      <description translatable="no">
         <p>Fix: audio mapping, so all streams are reencoded</p>
         <p>Fix: typos</p>
         <p>Fix: more concise version number in about window</p>
@@ -116,7 +116,7 @@
     </release>
     
     <release version="0.2.0" date="2023-02-11">
-      <description>
+      <description translatable="no">
         <p>I know it has been a long time coming, but this time, we have a plethora of changes to report!
           - Updated SVT-AV1 &amp; tuned for better visual quality
           - More buttons than just the close button in the header bar
@@ -135,13 +135,13 @@
     </release>
     
     <release version="0.1.2" date="2022-10-23">
-      <description>
+      <description translatable="no">
         <p>Fix: typos</p>
       </description>
     </release>
 
     <release version="0.1.1" date="2022-10-20">
-      <description>
+      <description translatable="no">
         <p>Fix: support multiple streams</p>
         <p>Fix: add encode time to end notification</p>
         <p>Fix: enable VBR by default</p>
@@ -150,7 +150,7 @@
     </release>
 
     <release version="0.1.0" date="2022-09-08">
-      <description>
+      <description translatable="no">
         <p>Initial release</p>
       </description>
     </release>

--- a/po/aviator.pot
+++ b/po/aviator.pot
@@ -1,0 +1,237 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-09-30 21:56+0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/net.natesales.Aviator.desktop:4 src/startup.ui:6 src/window.ui:20
+msgid "Aviator"
+msgstr ""
+
+#: data/net.natesales.Aviator.desktop:5
+msgid "AV1/OPUS Video Encoder"
+msgstr ""
+
+#: src/startup.ui:33
+msgid "Welcome to Aviator"
+msgstr ""
+
+#: src/startup.ui:34
+msgid "Your video copilot is ready for takeoff!"
+msgstr ""
+
+#: src/startup.ui:42
+msgid "Go"
+msgstr ""
+
+#: src/window.ui:8
+msgid "_About"
+msgstr ""
+
+#: src/window.ui:12
+msgid "Quit"
+msgstr ""
+
+#: src/window.ui:49
+msgid "_Video"
+msgstr ""
+
+#: src/window.ui:59
+msgid "Open"
+msgstr ""
+
+#: src/window.ui:61
+msgid "Open your source media."
+msgstr ""
+
+#: src/window.ui:95
+msgid "_Source File"
+msgstr ""
+
+#: src/window.ui:97
+msgid "Displays the source filename."
+msgstr ""
+
+#: src/window.ui:108
+msgid "_Resolution"
+msgstr ""
+
+#: src/window.ui:110
+msgid ""
+"Sets the output resolution. Width & height will match the source media if "
+"left empty. Putting in one value will automatically calculate the other "
+"based on the source video's aspect ratio if \"Crop\" is unchecked; "
+"otherwise, the empty value will match the original."
+msgstr ""
+
+#: src/window.ui:141
+msgid "Width"
+msgstr ""
+
+#: src/window.ui:147
+msgid "Height"
+msgstr ""
+
+#: src/window.ui:179
+msgid "CRF"
+msgstr ""
+
+#: src/window.ui:180
+msgid ""
+"The CRF value determines the size & quality of your output. Higher values "
+"mean lower file size & quality while lower values create larger, higher-"
+"quality videos."
+msgstr ""
+
+#: src/window.ui:205
+msgid "_Speed"
+msgstr ""
+
+#: src/window.ui:206
+msgid ""
+"This value determines how hard your system will work to encode your video. "
+"Lower values mean your system will take longer to encode the video, but the "
+"files will be higher quality. Higher values will encode less efficiently, "
+"but much more quickly."
+msgstr ""
+
+#: src/window.ui:214
+msgid ""
+"Adaptively detects screen content, like screen recordings or animation. It "
+"is highly recommended to leave this alone; disabling content adaptive SCM "
+"force-enables screen content detection, decreasing encoding efficiency for "
+"sparse visual benefit."
+msgstr ""
+
+#: src/window.ui:241
+msgid "_Grain Synth"
+msgstr ""
+
+#: src/window.ui:242
+msgid ""
+"This value determines how much artificial grain will be applied to your "
+"video. Use when your source has grain."
+msgstr ""
+
+#: src/window.ui:250
+msgid ""
+"Denoises the input video before adding film grain. Determined based on the "
+"amount of added grain. Can reduce detail retention, so it is disabled by "
+"default."
+msgstr ""
+
+#: src/window.ui:287
+msgid "_Audio"
+msgstr ""
+
+#: src/window.ui:321
+msgid "_Bitrate"
+msgstr ""
+
+#: src/window.ui:323
+msgid ""
+"Sets the audio bitrate to a value in kb/s. Higher values mean better quality "
+"at the expense of filesize. We recommend a value between 32 & 128 for stereo "
+"audio, >224 for 5.1 Surround, & >336 for 7.1 Surround. If a value from the "
+"source media isn't detected, this will default to 80 kb/s. "
+msgstr ""
+
+#: src/window.ui:333
+msgid "kb/s"
+msgstr ""
+
+#: src/window.ui:344
+msgid "_Downmix to Stereo"
+msgstr ""
+
+#: src/window.ui:346
+msgid ""
+"Mixes audio inputs with more than two channels (5.1 Surround, 7.1 Surround, "
+"etc) down to two audio channels."
+msgstr ""
+
+#: src/window.ui:359
+msgid "_Copy Audio"
+msgstr ""
+
+#: src/window.ui:361 src/window.ui:367
+msgid ""
+"Ignores all options on this page & copies audio directly from the source "
+"untouched. Disables WebM output."
+msgstr ""
+
+#: src/window.ui:382
+msgid "_Volume"
+msgstr ""
+
+#: src/window.ui:383
+msgid ""
+"Increase or decrease audio volume. Measured in decibles. Positive numbers "
+"will increase volume while negative numbers will decrease it."
+msgstr ""
+
+#: src/window.ui:391
+msgid "Normalize the audio's perceived loudness."
+msgstr ""
+
+#: src/window.ui:429
+msgid "_Export"
+msgstr ""
+
+#: src/window.ui:446
+msgid "_Output File"
+msgstr ""
+
+#: src/window.ui:448
+msgid "Select the output directory & type in a filename."
+msgstr ""
+
+#: src/window.ui:480
+msgid "_Container"
+msgstr ""
+
+#: src/window.ui:482
+msgid ""
+"The container your video is stored in, which is associated with the file "
+"extension. MKV is a universal video container with widespread support, while "
+"WebM is designed for web compatibility & may break subtitles."
+msgstr ""
+
+#: src/window.ui:495
+msgid "Selecting WebM output will strip subtitles for compatibility reasons."
+msgstr ""
+
+#: src/window.ui:500
+msgid "MKV"
+msgstr ""
+
+#: src/window.ui:506
+msgid "WEBM"
+msgstr ""
+
+#: src/window.ui:522
+msgid "Encode"
+msgstr ""
+
+#: src/window.ui:524
+msgid ""
+"Begin encoding! Watch the progress bar to see how quickly your encode is "
+"progressing."
+msgstr ""
+
+#: src/window.ui:558
+msgid "Stop"
+msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: net.natesales.Aviator\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-14 14:51+0300\n"
-"PO-Revision-Date: 2023-06-14 15:02+0300\n"
+"POT-Creation-Date: 2023-09-30 21:56+0300\n"
+"PO-Revision-Date: 2023-09-30 22:00+0300\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: Türkçe <takim@gnome.org.tr>\n"
 "Language: tr\n"
@@ -17,6 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.3.2\n"
 
 #: data/net.natesales.Aviator.desktop:4 src/startup.ui:6 src/window.ui:20
 msgid "Aviator"
@@ -62,9 +63,9 @@ msgstr "Kaynak ortamınızı açın."
 msgid "_Source File"
 msgstr "_Kaynak Dosya"
 
-#: src/window.ui:100
-msgid "Displays the path to the source file."
-msgstr "Kaynak dosya yolunu görüntüler."
+#: src/window.ui:97
+msgid "Displays the source filename."
+msgstr "Kaynak dosya adını görüntüler."
 
 #: src/window.ui:108
 msgid "_Resolution"
@@ -74,25 +75,27 @@ msgstr "_Çözünürlük:"
 msgid ""
 "Sets the output resolution. Width & height will match the source media if "
 "left empty. Putting in one value will automatically calculate the other "
-"based on the source video's aspect ratio."
+"based on the source video's aspect ratio if \"Crop\" is unchecked; "
+"otherwise, the empty value will match the original."
 msgstr ""
 "Çıktı çözünürlüğünü ayarlar. Genişlik ve yükseklik, boş bırakılırsa kaynak "
-"ortamla eşleşir. Bir değer girildiğinde, kaynak videonun en boy oranına göre "
-"diğer değer kendiliğinden hesaplanır."
+"ortamla eşleşir. \"Kırp\" işaretlenmemişse, bir değer girildiğinde diğer "
+"değer kaynak videonun en boy oranına göre kendiliğinden hesaplanır; aksi "
+"takdirde boş değer orijinalle eşleşir."
 
-#: src/window.ui:132
+#: src/window.ui:141
 msgid "Width"
 msgstr "Genişlik"
 
-#: src/window.ui:138
+#: src/window.ui:147
 msgid "Height"
 msgstr "Yükseklik"
 
-#: src/window.ui:170
+#: src/window.ui:179
 msgid "CRF"
 msgstr "CRF"
 
-#: src/window.ui:171
+#: src/window.ui:180
 msgid ""
 "The CRF value determines the size & quality of your output. Higher values "
 "mean lower file size & quality while lower values create larger, higher-"
@@ -102,11 +105,11 @@ msgstr ""
 "daha düşük dosya boyutu ve kalitesi anlamına gelirken daha düşük değerler "
 "daha büyük, daha yüksek kaliteli videolar oluşturur."
 
-#: src/window.ui:196
+#: src/window.ui:205
 msgid "_Speed"
 msgstr "_Hız"
 
-#: src/window.ui:197
+#: src/window.ui:206
 msgid ""
 "This value determines how hard your system will work to encode your video. "
 "Lower values mean your system will take longer to encode the video, but the "
@@ -118,11 +121,23 @@ msgstr ""
 "süreceği, ancak dosyaların daha kaliteli olacağı anlamına gelir. Daha yüksek "
 "değerler daha az verimli ancak çok daha hızlı kodlayacaktır."
 
-#: src/window.ui:223
+#: src/window.ui:214
+msgid ""
+"Adaptively detects screen content, like screen recordings or animation. It "
+"is highly recommended to leave this alone; disabling content adaptive SCM "
+"force-enables screen content detection, decreasing encoding efficiency for "
+"sparse visual benefit."
+msgstr ""
+"Ekran kayıtları veya animasyon gibi ekran içeriğini uyarlamalı olarak "
+"algılar. Bunun yapılmaması şiddetle tavsiye edilir; içerik uyarlamalı "
+"SCM'nin devre dışı bırakılması ekran içeriği algılamayı zorlayarak seyrek "
+"görsel fayda için kodlama verimliliğini azaltır."
+
+#: src/window.ui:241
 msgid "_Grain Synth"
 msgstr "_Tane Sentezi"
 
-#: src/window.ui:224
+#: src/window.ui:242
 msgid ""
 "This value determines how much artificial grain will be applied to your "
 "video. Use when your source has grain."
@@ -130,7 +145,7 @@ msgstr ""
 "Bu değer, videonuza ne kadar yapay tane uygulanacağını belirler. "
 "Kaynağınızda tane olduğunda kullanın."
 
-#: src/window.ui:232
+#: src/window.ui:250
 msgid ""
 "Denoises the input video before adding film grain. Determined based on the "
 "amount of added grain. Can reduce detail retention, so it is disabled by "
@@ -140,15 +155,15 @@ msgstr ""
 "tane miktarına göre belirlenir. Ayrıntıların saklanmasını azaltabilir, "
 "dolayısıyla öntanımlı olarak devre dışıdır."
 
-#: src/window.ui:269
+#: src/window.ui:287
 msgid "_Audio"
 msgstr "_Ses"
 
-#: src/window.ui:303
+#: src/window.ui:321
 msgid "_Bitrate"
 msgstr "_Bit Oranı"
 
-#: src/window.ui:305
+#: src/window.ui:323
 msgid ""
 "Sets the audio bitrate to a value in kb/s. Higher values mean better quality "
 "at the expense of filesize. We recommend a value between 32 & 128 for stereo "
@@ -158,18 +173,18 @@ msgstr ""
 "Ses bit hızını kb/s cinsinden bir değere ayarlar. Daha yüksek değerler, "
 "dosya boyutu pahasına daha iyi kalite anlamına gelir. Stereo ses için 32 ve "
 "128, 5.1 Surround için >224 ve 7.1 Surround için >336 arasında bir değer "
-"önerilir. Kaynak ortamdan bir değer algılanmazsa, bu öntanımlı olarak 48 "
-"kb/s olacaktır."
+"önerilir. Kaynak ortamdan bir değer algılanmazsa, bu öntanımlı olarak 48 kb/"
+"s olacaktır."
 
-#: src/window.ui:315
+#: src/window.ui:333
 msgid "kb/s"
 msgstr "kb/s"
 
-#: src/window.ui:326
+#: src/window.ui:344
 msgid "_Downmix to Stereo"
 msgstr "_İki Ses Kanalına Dönüştür"
 
-#: src/window.ui:328
+#: src/window.ui:346
 msgid ""
 "Mixes audio inputs with more than two channels (5.1 Surround, 7.1 Surround, "
 "etc) down to two audio channels."
@@ -177,11 +192,11 @@ msgstr ""
 "İkiden fazla kanallı (5.1 Surround, 7.1 Surround, vb.) ses girişlerini iki "
 "ses kanalına dönüştürür."
 
-#: src/window.ui:341
+#: src/window.ui:359
 msgid "_Copy Audio"
 msgstr "Sesi _Kopyala"
 
-#: src/window.ui:343
+#: src/window.ui:361 src/window.ui:367
 msgid ""
 "Ignores all options on this page & copies audio directly from the source "
 "untouched. Disables WebM output."
@@ -189,11 +204,11 @@ msgstr ""
 "Bu sayfadaki tüm seçenekleri yok sayar ve sesi doğrudan kaynaktan el "
 "değmeden kopyalar. WebM çıkışını devre dışı bırakır."
 
-#: src/window.ui:356
+#: src/window.ui:382
 msgid "_Volume"
 msgstr "_Ses"
 
-#: src/window.ui:357
+#: src/window.ui:383
 msgid ""
 "Increase or decrease audio volume. Measured in decibles. Positive numbers "
 "will increase volume while negative numbers will decrease it."
@@ -201,27 +216,27 @@ msgstr ""
 "Ses seviyesini artır veya azalt. Desibel cinsinden ölçülür. Pozitif sayılar "
 "sesi artırır, negatif sayılar ise azaltır."
 
-#: src/window.ui:365
+#: src/window.ui:391
 msgid "Normalize the audio's perceived loudness."
 msgstr "Sesin algılanan yüksekliğini normalleştir."
 
-#: src/window.ui:403
+#: src/window.ui:429
 msgid "_Export"
 msgstr "_Dışa Aktar"
 
-#: src/window.ui:420
+#: src/window.ui:446
 msgid "_Output File"
 msgstr "_Çıktı Dosyası"
 
-#: src/window.ui:422
+#: src/window.ui:448
 msgid "Select the output directory & type in a filename."
 msgstr "Çıkış dizinini seçin ve bir dosya adı yazın."
 
-#: src/window.ui:454
+#: src/window.ui:480
 msgid "_Container"
 msgstr "Kapsayıcı"
 
-#: src/window.ui:456
+#: src/window.ui:482
 msgid ""
 "The container your video is stored in, which is associated with the file "
 "extension. MKV is a universal video container with widespread support, while "
@@ -231,24 +246,24 @@ msgstr ""
 "yaygın desteği olan evrensel bir video kapsayıcıdır, WebM ise web uyumluluğu "
 "için tasarlanmıştır ve altyazıları bozabilir."
 
-#: src/window.ui:469
+#: src/window.ui:495
 msgid "Selecting WebM output will strip subtitles for compatibility reasons."
 msgstr ""
 "WebM çıkışının seçilmesi, uyumluluk nedenleriyle altyazıları gözardı eder."
 
-#: src/window.ui:474
+#: src/window.ui:500
 msgid "MKV"
 msgstr "MKV"
 
-#: src/window.ui:480
+#: src/window.ui:506
 msgid "WEBM"
 msgstr "WEBM"
 
-#: src/window.ui:496
+#: src/window.ui:522
 msgid "Encode"
 msgstr "Kodla"
 
-#: src/window.ui:498
+#: src/window.ui:524
 msgid ""
 "Begin encoding! Watch the progress bar to see how quickly your encode is "
 "progressing."
@@ -256,6 +271,6 @@ msgstr ""
 "Kodlamaya başlayın! Kodlamanızın ne kadar hızlı ilerlediğini görmek için "
 "ilerleme çubuğunu izleyebilirsiniz."
 
-#: src/window.ui:532
+#: src/window.ui:558
 msgid "Stop"
 msgstr "Durdur"


### PR DESCRIPTION
GNOME automatically excludes release descriptions on Damned Lies (GNOME Translation Platform). It's a good practice to follow the GNOME way.

This can streamline the translation process, allowing translators to focus their efforts on more critical and user-facing aspects of the application.