### PR TITLE
Add screenshot captions in metainfo file

### DIFF
--- a/data/net.natesales.Aviator.metainfo.xml.in
+++ b/data/net.natesales.Aviator.metainfo.xml.in
@@ -45,15 +45,19 @@
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/gianni-rosato/aviator/main/assets/aviator_welcome.png</image>
+      <caption>Welcome screen</caption>
     </screenshot>
     <screenshot>
       <image>https://raw.githubusercontent.com/gianni-rosato/aviator/main/assets/aviator_video.png</image>
+      <caption>Video screen with tweak options</caption>
     </screenshot>
     <screenshot>
       <image>https://raw.githubusercontent.com/gianni-rosato/aviator/main/assets/aviator_audio.png</image>
+      <caption>Audio screen with tweak options</caption>
     </screenshot>
     <screenshot>
       <image>https://raw.githubusercontent.com/gianni-rosato/aviator/main/assets/aviator_output.png</image>
+      <caption>Export screen</caption>
     </screenshot>
   </screenshots>
 


### PR DESCRIPTION
This contribution is part of [GUADEC 2024's Accessibility Hackathon](https://pesader.dev/posts/accessibility-hackathon/) initiative to include caption to increase accessibility when browsing apps in app stores. These captions are shown below the screenshot carousel in Flathub.