### PR TITLE
build: load hicolor icon as 256x256 instead of scalable

### DIFF
--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -1,7 +1,7 @@
 hicolor_dir = get_option('datadir') / 'icons/hicolor'
 
 install_data('net.natesales.Aviator.png',
-  install_dir: hicolor_dir/'scalable/apps',
+  install_dir: hicolor_dir/'256x256/apps',
 )
 
 install_data('net.natesales.Aviator-symbolic.svg',


### PR DESCRIPTION
This is a small tweak, no functional change.

The Scalable directory is for `.svg` icons while for the various other resolutions there should be a corresponding folder ("32x32","64x64",...).
Since the icon is a 256x256 `.png` it's best to alter the directory structure.